### PR TITLE
Display icons below room number on mobile layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ more detailed documentation about the site organization:
 
 download all dependencies including dev
 
+note: currently, node v10.x is needed for gulp to work properly
+
 ```
 $ npm install
 ```

--- a/src/scss/pages/_schedule.scss
+++ b/src/scss/pages/_schedule.scss
@@ -106,7 +106,7 @@
     .event,
     .milestone {
       display: grid;
-      grid-template-columns: 1fr 3fr 1fr 1fr;
+      grid-template-columns: 1fr 3fr 2fr;
       grid-gap: 20px;
       padding: 16px 0px;
       border-top: 1px solid rgba($primary-text, 0.5);
@@ -114,6 +114,11 @@
       .time,
       .room {
         color: rgba($primary-text, 0.5);
+      }
+      .room-res-container {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-around;
       }
       .lecturer {
         font-size: 0.8em;
@@ -185,9 +190,11 @@
     display: inline-block;
   }
 
-  .resources {
-    display: none;
+  .room-res-container {
+    flex-direction: column !important;
+    justify-content: flex-start !important;
   }
+
   .lec,
   .oh,
   .event,

--- a/src/views/content/schedule.pug
+++ b/src/views/content/schedule.pug
@@ -73,14 +73,15 @@ mixin event_details(event)
     span= event.name
     if event.who
       .lecturer Lecturer: #{event.who}
-  .room= event.where
-  if event.links
-    .resources
-      for resource in event.links
-        a(href=resource.link)
-          if resource.type == "youtube"
-            <i class="fab fa-youtube"></i>
-          else if resource.type == "slides"
-            <i class="far fa-file-pdf"></i>
-          else if resource.type == "info"
-            <i class="fas fa-info"></i>
+  .room-res-container
+    .room= event.where
+    if event.links
+      .resources
+        for resource in event.links
+          a(href=resource.link)
+            if resource.type == "youtube"
+              <i class="fab fa-youtube"></i>
+            else if resource.type == "slides"
+              <i class="far fa-file-pdf"></i>
+            else if resource.type == "info"
+              <i class="fas fa-info"></i>


### PR DESCRIPTION
Seemed to work in my super brief testing. Adds the resource icons below the room number on mobile, which there seems to be space enough for. Layouts on desktop theoretically should be equivalent to before. 

Looks like this: 
![image](https://user-images.githubusercontent.com/14306044/72472467-9a42d900-37b2-11ea-965f-6889fc820f7b.png)
